### PR TITLE
Improve specifications in existing examples

### DIFF
--- a/provers/native/prover_why3.ml
+++ b/provers/native/prover_why3.ml
@@ -737,6 +737,8 @@ and core_lang_to_whyml tenv e =
       match s with
       | "+" | "-" | ">" | "<" | ">=" | "<=" -> qualid ["Int"; Ident.op_infix s]
       | "=" -> qualid ["Int"; Ident.op_infix s] (* for now *)
+      | "||" -> qualid ["Bool"; "orb"]
+      | "&&" -> qualid ["Bool"; "andb"]
       | _ -> qualid [s]
     in
     tapp fn (List.map (term_to_whyml tenv) args)

--- a/src/examples/later/accumulator_factory.ml
+++ b/src/examples/later/accumulator_factory.ml
@@ -1,0 +1,17 @@
+
+(* https://rosettacode.org/wiki/Accumulator_factory *)
+
+let accumulator init =
+  let total = ref init in
+  fun n ->
+    total := !total + n;
+    !total
+
+let test n
+(*@ ens res=n @*)
+= let acc = accumulator 0 in
+  let rec repeat x n =
+    if n = 0 then (acc 0)
+    else acc x; repeat x (n - 1)
+  in
+  repeat 1 n

--- a/src/examples/later/accumulator_factory.ml
+++ b/src/examples/later/accumulator_factory.ml
@@ -3,15 +3,26 @@
 
 let accumulator init =
   let total = ref init in
-  fun n ->
-    total := !total + n;
-    !total
+  let acc x
+  (*@ ex t; req total->t; ens total->t+x @*)
+  = total := !total + x; !total in
+  acc
 
-let test n
-(*@ ens res=n @*)
-= let acc = accumulator 0 in
+external sum : int -> int -> int -> int = "accumulator_factory.Extras.sum"
+
+let sum_aux x n init =
+  let total = ref init in
+  let rec aux x n =
+    if n = 0 then !total
+    else let _ = total := !total + x in aux x (n - 1)
+  in
+  aux n
+
+let test init x n
+(*@ ex r; sum_aux(x,n,init,r); ens res=r @*)
+= let acc = accumulator init in
   let rec repeat x n =
     if n = 0 then (acc 0)
-    else acc x; repeat x (n - 1)
+    else let r = acc x in repeat x (n - 1)
   in
-  repeat 1 n
+  repeat x n

--- a/src/examples/later/accumulator_factory.why
+++ b/src/examples/later/accumulator_factory.why
@@ -1,0 +1,11 @@
+
+module Extras
+
+  use int.Int
+
+  let rec ghost function sum (x:int) (n:int) (total:int) : int
+  requires { n >= 0 }
+  variant { n }
+  = if n = 0 then total
+    else sum x (n - 1) (total + x)
+  end

--- a/src/examples/list.ml
+++ b/src/examples/list.ml
@@ -19,15 +19,39 @@ let rec interleave xs ys =
   | y :: ys' -> x :: (y :: interleave xs' ys')
 
 
-(* List scanning/searching: https://v2.ocaml.org/api/List.html *)
+(* OCaml List Module: https://v2.ocaml.org/api/List.html *)
 
-(* Returns the index of y in lst if it exists, or the length of lst *)
+(* https://v2.ocaml.org/api/List.html#VALfind_index *)
 let rec find_index lst y =
   match lst with
   | [] -> 0
   | x :: xs -> if x = y then 0 else 1 + (find_index xs y)
 
+(* https://v2.ocaml.org/api/List.html#VALexists *)
 let rec exists lst f =
   match lst with
   | [] -> false
   | x :: xs -> f x || exists xs f
+
+(* https://v2.ocaml.org/api/List.html#VALint *)
+let init len f =
+  if len < 0 then perform Invalid_argument;
+  let rec aux idx
+  = if idx = len then []
+    else let k = f idx in k :: aux (idx + 1)
+  in
+  aux 0
+
+(* https://v2.ocaml.org/api/List.html#VALequal *)
+let rec equal xs ys =
+  match xs with
+  | [] -> (
+    match ys with
+    | [] -> true
+    | y :: ys' -> false
+  )
+  | x :: xs' -> (
+    match ys with
+    | [] -> false
+    | y :: ys' -> x = y && equal xs' ys'
+  )

--- a/src/program-proofs/chapter06/append.ml
+++ b/src/program-proofs/chapter06/append.ml
@@ -15,6 +15,8 @@ let append_nil xs
 (*@ ens res=xs @*)
 = append xs []    
 
-let length_append xs ys (* FIXME *)
-(*@ ens res=length(xs)+length(ys) @*)
-= length (append xs ys)
+external length_append : int list -> int list -> int list -> bool = "append.Extras.length_append"
+
+let test_length_append xs ys
+(*@ ens length_append(xs,ys,res)=true @*)
+= append xs ys

--- a/src/program-proofs/chapter06/append.why
+++ b/src/program-proofs/chapter06/append.why
@@ -1,0 +1,15 @@
+
+module Extras
+
+  use list.List
+  use int.Int
+
+  function length (xs:list int) : int =
+    match xs with
+    | Nil -> 0
+    | Cons x xs1 -> 1 + length xs1
+    end
+
+  function length_append (xs:list int) (ys: list int) (res: list int) : bool =
+    length xs + length ys = length res
+end

--- a/src/program-proofs/chapter06/append.why
+++ b/src/program-proofs/chapter06/append.why
@@ -10,6 +10,6 @@ module Extras
     | Cons x xs1 -> 1 + length xs1
     end
 
-  function length_append (xs:list int) (ys: list int) (res: list int) : bool =
+  function length_append (xs:list int) (ys:list int) (res:list int) : bool =
     length xs + length ys = length res
-end
+    end

--- a/src/program-proofs/chapter06/at.ml
+++ b/src/program-proofs/chapter06/at.ml
@@ -6,7 +6,10 @@ let[@pure] rec length (xs: int list): int
 
 (* Example 6.4 *)
 let rec at xs i
-(*@ req i>=0/\i<length(xs) @*)
 = match xs with
   | [] -> 0
   | x :: xs' -> if i = 0 then x else at xs' (i - 1)
+
+let at_spec xs i
+(*@ req i>=0/\i<length(xs) @*)
+= at xs i

--- a/src/program-proofs/chapter06/find.ml
+++ b/src/program-proofs/chapter06/find.ml
@@ -9,10 +9,6 @@ let[@pure] rec at (xs: int list) (i: int): int
   | [] -> 0
   | x :: xs' -> if i = 0 then x else at xs' (i - 1)
 
-let test_at xs i
-(*@ req i>=0/\i<length(xs) @*)
-= at xs i
-
 (* Example 6.5 *)
 let[@pure] rec find (xs: int list) (y: int): int
 = match xs with

--- a/src/program-proofs/chapter06/find.ml
+++ b/src/program-proofs/chapter06/find.ml
@@ -12,7 +12,7 @@ let[@pure] rec at (xs: int list) (i: int): int
 
 (* Example 6.5 *)
 let[@pure] rec find (xs: int list) (y: int): int
-(*@ ex r; req res=r; ens r>=0/\r<=length(xs)/\res=r @*)
+(*@ ex r; ens r>=0/\r<=length(xs)/\res=r @*)
 = match xs with
 | [] -> 0
 | x :: xs' -> if x = y then 0 else 1 + find xs' y

--- a/src/program-proofs/chapter06/find.ml
+++ b/src/program-proofs/chapter06/find.ml
@@ -5,19 +5,25 @@ let[@pure] rec length (xs: int list): int
   | x :: xs1 -> 1 + length xs1
 
 let[@pure] rec at (xs: int list) (i: int): int
-(*@ req i>=0/\i<length(xs) @*)
 = match xs with
   | [] -> 0
   | x :: xs' -> if i = 0 then x else at xs' (i - 1)
 
+let test_at xs i
+(*@ req i>=0/\i<length(xs) @*)
+= at xs i
+
 (* Example 6.5 *)
 let[@pure] rec find (xs: int list) (y: int): int
-(*@ ex r; ens r>=0/\r<=length(xs)/\res=r @*)
 = match xs with
 | [] -> 0
 | x :: xs' -> if x = y then 0 else 1 + find xs' y
 
-let at_find xs y
+let test_find_index xs y
+(*@ req length(xs)>=0; ens res>=0/\res<=length(xs) @*)
+= find xs y
+
+let test_at_find xs y (* FIXME *)
 (*@
   ex r; ens r=length(xs)/\res=r
   \/ ex r; ens at(xs,r)=y/\res=r

--- a/src/program-proofs/chapter06/reverse.ml
+++ b/src/program-proofs/chapter06/reverse.ml
@@ -4,17 +4,17 @@ let[@pure] rec length (xs: int list): int
   | [] -> 0
   | x :: xs1 -> 1 + length xs1
 
-let[@pure] rec snoc (lst: int list) (x: int): int list =
+let rec snoc lst x =
   match lst with
   | [] -> [x]
   | y :: ys -> y :: snoc ys x
 
 (* Example 6.6 *)
-let[@pure] rec reverse (xs: int list): int list =
+let rec reverse xs =
   match xs with
   | [] -> []
   | x :: xs' -> snoc (reverse xs') x 
 
-let length_reverse xs
+let length_reverse xs (* FIXME *)
 (*@ ens res=length(xs) @*)
 = length (reverse xs)

--- a/src/program-proofs/chapter06/snoc.ml
+++ b/src/program-proofs/chapter06/snoc.ml
@@ -9,6 +9,8 @@ let rec snoc lst x =
   | [] -> [x]
   | y :: ys -> y :: snoc ys x
 
-let length_snoc xs x (* FIXME *)
-(*@ ens res=length(xs)+1 @*)
-= length (snoc xs x)
+external length_snoc : int list -> int -> int list -> bool = "snoc.Extras.length_snoc"
+
+let length_snoc xs x
+(*@ ens length_snoc(xs, x, res)=true @*)
+= snoc xs x

--- a/src/program-proofs/chapter06/snoc.why
+++ b/src/program-proofs/chapter06/snoc.why
@@ -10,6 +10,6 @@ module Extras
     | Cons x xs1 -> 1 + length xs1
     end
 
-  function length_snoc (xs:list int) (x: int) (res: list int) : bool =
+  function length_snoc (xs:list int) (x:int) (res:list int) : bool =
     length xs + 1 = length res
-end
+    end

--- a/src/program-proofs/chapter06/snoc.why
+++ b/src/program-proofs/chapter06/snoc.why
@@ -1,0 +1,15 @@
+
+module Extras
+
+  use list.List
+  use int.Int
+
+  function length (xs:list int) : int =
+    match xs with
+    | Nil -> 0
+    | Cons x xs1 -> 1 + length xs1
+    end
+
+  function length_snoc (xs:list int) (x: int) (res: list int) : bool =
+    length xs + 1 = length res
+end

--- a/src/program-proofs/chapter06/take_drop.ml
+++ b/src/program-proofs/chapter06/take_drop.ml
@@ -34,8 +34,10 @@ let append_take_drop xs n (* FIXME: By induction *)
 
 let take_drop_append1 xs ys (* FIXME *)
 (*@ ens res=xs @*)
+(* Workaround to avoid type errors in Why3 *)
 = let n = length xs in take_spec (append xs ys) n
 
 let take_drop_append2 xs ys (* FIXME *)
 (*@ ens res=ys @*)
+(* Workaround to avoid type errors in Why3 *)
 = let n = length xs in drop_spec (append xs ys) n

--- a/src/program-proofs/chapter06/take_drop.ml
+++ b/src/program-proofs/chapter06/take_drop.ml
@@ -4,32 +4,38 @@ let[@pure] rec length (xs: int list): int
   | [] -> 0
   | x :: xs1 -> 1 + length xs1
 
-let[@pure] rec append (xs: int list) (ys: int list): int list =
+let rec append xs ys =
   match xs with
   | [] -> ys
   | x :: xs' -> x :: append xs' ys
 
 (* Example 6.3 *)
-let[@pure] rec take (xs: int list) (n: int): int list
-(*@ req n>=0/\n<=length(xs) @*)
+let rec take xs n
 = if n = 0 then [] else match xs with
 | [] -> []
 | x :: xs' -> x :: take xs' (n - 1)
 
-let[@pure] rec drop (xs: int list) (n: int): int list
+let take_spec xs n
 (*@ req n>=0/\n<=length(xs) @*)
+= take xs n
+
+let rec drop xs n
 = if n = 0 then xs else match xs with
 | [] -> []
 | x :: xs' -> drop xs' (n - 1)
 
-let append_take_drop xs n
-(*@ req n>=0/\n<=length(xs); ens res=xs @*)
-= append (take xs n) (drop xs n)
+let drop_spec xs n
+(*@ req n>=0/\n<=length(xs) @*)
+= drop xs n
 
-let take_drop_append1 xs ys
+let append_take_drop xs n (* FIXME: By induction *)
 (*@ ens res=xs @*)
-= take (append xs ys) (length xs)
+= append (take_spec xs n) (drop_spec xs n)
 
-let take_drop_append2 xs ys
+let take_drop_append1 xs ys (* FIXME *)
+(*@ ens res=xs @*)
+= let n = length xs in take_spec (append xs ys) n
+
+let take_drop_append2 xs ys (* FIXME *)
 (*@ ens res=ys @*)
-= drop (append xs ys) (length xs)
+= let n = length xs in drop_spec (append xs ys) n

--- a/src/program-proofs/chapter08/insertion_sort.ml
+++ b/src/program-proofs/chapter08/insertion_sort.ml
@@ -5,20 +5,24 @@ let[@pure] rec is_sorted (xs: int list): bool =
   | x :: xs' -> (
     match xs' with
     | [] -> true
-    | x' :: xs'' -> x <= x' && is_sorted xs'
+    (* Note: && is not yet supported *)
+    | x' :: xs'' -> if x <= x' then is_sorted xs' else false
   )
 
-let[@pure] rec insert_in_sorted_list (v: int) (xs: int list): int list
+let rec insert_in_sorted_list v xs
 = match xs with
   | [] -> [v]
   | x :: xs' -> if v <= x then v :: xs else x :: insert_in_sorted_list v xs'
 
-let[@pure] insert_in_sorted_list_ (v: int) (xs: int list): int list (* FIXME *)
-(*@ req is_sorted(xs)=true; ex r; ens is_sorted(r)=true/\res=r @*)
+let insert_in_sorted_list_spec v xs (* FIXME *)
+(*@ req is_sorted(xs)=true; ens is_sorted(res)=true @*)
 = insert_in_sorted_list v xs
 
-let rec insertion_sort xs =
+let rec insertion_sort xs = (* FIXME *)
   match xs with
   | [] -> []
-  | x :: xs' -> insert_in_sorted_list x (insertion_sort xs')
+  | x :: xs' -> insert_in_sorted_list_spec x (insertion_sort xs')
 
+let insertion_sort_spec xs (* FIXME *)
+(*@ ens is_sorted(xs)=true @*)
+= insertion_sort xs

--- a/src/program-proofs/chapter08/insertion_sort.ml
+++ b/src/program-proofs/chapter08/insertion_sort.ml
@@ -5,8 +5,7 @@ let[@pure] rec is_sorted (xs: int list): bool =
   | x :: xs' -> (
     match xs' with
     | [] -> true
-    (* Note: && is not yet supported *)
-    | x' :: xs'' -> if x <= x' then is_sorted xs' else false
+    | x' :: xs'' -> x <= x' && is_sorted xs'
   )
 
 let rec insert_in_sorted_list v xs

--- a/src/prusti/hanoi.ml
+++ b/src/prusti/hanoi.ml
@@ -1,0 +1,30 @@
+
+(* https://github.com/viperproject/prusti-dev/blob/master/prusti-tests/tests/verify_overflow/pass/rosetta/Towers_of_Hanoi_spec.rs *)
+
+let[@pure] valid_pole (x: int): bool =
+  (* Temporary workaround for || *)
+  if x = 1 then true
+  else if x = 2 then true
+  else if x = 3 then true
+  else false
+
+let[@pure] equals (a: int) (b: int): bool = a = b
+
+let record_move src dest
+(*@ req valid_pole(src)=true/\valid_pole(dest)=true/\equals(src, dest)=false @*)
+= ()
+
+let rec move n src dest via =
+  if n > 0 then
+    move (n - 1) src via dest;
+    record_move src dest;
+    move (n - 1) via dest src
+
+let move_spec n src dest via
+(*@
+  req n>=0/\valid_pole(src)=true/\valid_pole(dest)=true/\valid_pole(via)=true;
+  req equals(src,dest)=false/\equals(dest,via)=false/\equals(via,src)=false;
+  ex r; move(n,src,dest,via,r);
+  ens res=r
+@*)
+= move n src dest via

--- a/src/prusti/hanoi.ml
+++ b/src/prusti/hanoi.ml
@@ -1,12 +1,7 @@
 
 (* https://github.com/viperproject/prusti-dev/blob/master/prusti-tests/tests/verify_overflow/pass/rosetta/Towers_of_Hanoi_spec.rs *)
 
-let[@pure] valid_pole (x: int): bool =
-  (* Temporary workaround for || *)
-  if x = 1 then true
-  else if x = 2 then true
-  else if x = 3 then true
-  else false
+let[@pure] valid_pole (x: int): bool = x = 1 || x = 2 || x = 3
 
 let[@pure] equals (a: int) (b: int): bool = a = b
 


### PR DESCRIPTION
Fix existing specifications, in particular:
- Remove unnecessary `pure` annotations 
- Include length example for append/snoc in Why3