### PR TITLE
Add env var to disable typing of formulas during entailment checking

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,13 @@ Some of the environment variables Heifer interprets may be useful for testing.
 Setting `TEST=1` causes Heifer to print only whether a test has failed, which is useful for integration tests.
 A test in this context is a function whose main entailment proof must succeed; if its name has the suffix `_false`, the entailment must fail.
 
+## Untyped extensions
+
+Some extensions not supported by mainline OCaml are supported. Currently, this only includes delimited continuation operators (ala [OchaCaml](https://www.is.ocha.ac.jp/~asai/OchaCaml/)), but more may be supported.
+
+Setting `NOTYPES=1` will defer all typechecking during entailment checks until necessary (i.e. before SMT translation). This may be useful to ease development of extensions
+outside of those typechecked by OCaml.
+
 ## Logging and tracing
 
 View log output by setting `DEBUG=n`.

--- a/lib/hipcore_typed/dune
+++ b/lib/hipcore_typed/dune
@@ -1,7 +1,8 @@
 (library
  (name hipcore_typed)
  (public_name heifer.hipcore_typed)
- (modules subst typedhip pretty untypehip retypehip patterns syntax patterns globals rewrite_context variables typed_core_ast)
+ (modules subst typedhip pretty untypehip retypehip patterns syntax patterns globals rewrite_context variables typed_core_ast
+   dynamic_typing)
  (libraries debug unionFind str utils hipcore)
  (inline_tests)
  (preprocess (pps ppx_expect ppx_deriving.std visitors.ppx)))

--- a/lib/hipcore_typed/dynamic_typing.ml
+++ b/lib/hipcore_typed/dynamic_typing.ml
@@ -1,0 +1,34 @@
+open Typedhip
+
+let status = ref false
+
+let set_dynamic_typing () = status := true
+
+let dynamic_typing_enabled () = !status
+
+let spec_visitor f = object
+  inherit [_] map_spec
+
+  method! visit_typ _ t = f t
+end
+
+let type_with_any_spec s = (spec_visitor (fun _ -> Any))#visit_staged_spec () s
+
+let instantiate_any_types_pi p = (spec_visitor (fun _ -> TVar (Variables.fresh_variable ())))#visit_pi () p
+
+let check_for_untyped_visitor = object
+  inherit [_] reduce_spec
+
+  method zero = false
+  method plus = (||)
+
+  method! visit_CShift _ _ _ _ = true
+  method! visit_CReset _ _ = true
+
+  method! visit_Shift _ _ _ _ _ _ = true
+  method! visit_Reset _ _ = true
+end
+
+let uses_untyped_extensions_spec s = check_for_untyped_visitor#visit_staged_spec () s
+
+let uses_untyped_extensions_core c = check_for_untyped_visitor#visit_core_lang () c

--- a/lib/hipcore_typed/dynamic_typing.mli
+++ b/lib/hipcore_typed/dynamic_typing.mli
@@ -1,0 +1,23 @@
+open Typedhip
+
+(** Enable dynamic typing. This disables all type checks before translation to SMT.
+    This does not do anything by itself; relevant areas of the library whose
+    behaviors differ between untyped and typed mode must check this flag
+    using [dynamic_typing_enabled].
+
+    This must be called before any input is processed. *)
+val set_dynamic_typing : unit -> unit
+
+val dynamic_typing_enabled : unit -> bool
+
+(** Replace all types in this specification with [Any]. *)
+val type_with_any_spec : staged_spec -> staged_spec
+
+(** Replace all [Any] types in this pure formula with fresh type variables.
+    Inferring these types can be done using one of the [Infer_types] endpoints. *)
+val instantiate_any_types_pi : pi -> pi
+
+(* Currently, the only untyped extensions are shift/reset. *)
+
+val uses_untyped_extensions_spec : staged_spec -> bool
+val uses_untyped_extensions_core : core_lang -> bool

--- a/lib/hipcore_typed/dynamic_typing.mli
+++ b/lib/hipcore_typed/dynamic_typing.mli
@@ -5,7 +5,8 @@ open Typedhip
     behaviors differ between untyped and typed mode must check this flag
     using [dynamic_typing_enabled].
 
-    This must be called before any input is processed. *)
+    For a declaration to be processed in untyped mode, this must be called before
+    the declaration is processed. *)
 val set_dynamic_typing : unit -> unit
 
 val dynamic_typing_enabled : unit -> bool

--- a/lib/hipcore_typed/subst.ml
+++ b/lib/hipcore_typed/subst.ml
@@ -52,7 +52,8 @@ let reduce_visitor_function (type ctx_type) reduce_visitor (ctx_type : ctx_type 
 let find_non_term_binding x bindings =
   match List.assoc_opt x bindings with
   | Some {term_desc = Var name; _} -> name
-  | _ -> x
+  | Some _ -> failwith "Expected (Var _) for non-term substitution"
+  | None -> x
 
 let types_of_free_vars (type ctx_type) (ctx_type : ctx_type subst_context) (ctx : ctx_type) =
   let visitor =

--- a/lib/hipprover/entail.ml
+++ b/lib/hipprover/entail.ml
@@ -237,6 +237,8 @@ let check_pure_obligation left right =
      the untyped extensions. Perform another typechecking phase to perform these
      unifications. *)
   let (left, right), _ =
+    let left = Dynamic_typing.instantiate_any_types_pi left in
+    let right = Dynamic_typing.instantiate_any_types_pi right in
     let open Infer_types in
     with_empty_env begin
       let* left, right = infer_types_pair_pi left right in

--- a/main/hip.ml
+++ b/main/hip.ml
@@ -18,6 +18,10 @@ let () =
   Hiplib.(file_mode :=
     (Option.bind (Sys.getenv_opt "FILE") int_of_string_opt
     |> Option.value ~default:0) > 0);
+  begin
+  if Option.bind (Sys.getenv_opt "NOTYPES") int_of_string_opt |> Option.value ~default:0 > 0
+  then Hipcore_typed.Dynamic_typing.set_dynamic_typing ()
+  end;
   let ctf =
     Option.bind (Sys.getenv_opt "CTF") int_of_string_opt
     |> Option.value ~default:0 > 0


### PR DESCRIPTION
When the prover is run with `NOTYPES=1`, all types in staged formulas are replaced with `Any` to simplify the needed processing in situations where type inference is incomplete (e.g. when untyped extensions are present). Before SMT translation, all `Any`s are replaced with fresh type variables, and only then are types inferred.

Should there be a warning for when untyped extensions are used with types enabled?